### PR TITLE
Fix Album Cover Bugs

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Aplayer</name>
+	<comment>Project Aplayer created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/.project
+++ b/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1603044024368</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/.settings/org.eclipse.buildship.core.prefs
+++ b/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,13 @@
+arguments=
+auto.sync=false
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
+connection.project.dir=
+eclipse.preferences.version=1
+gradle.user.home=
+java.home=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.252.b09-0.fc31.x86_64
+jvm.arguments=
+offline.mode=false
+override.workspace.settings=true
+show.console.view=true
+show.executions.view=true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,12 +51,16 @@ android {
         debug {
             v1SigningEnabled true
             v2SigningEnabled true
+            storeFile file(var)
+            storePassword properties['keystore.storePassword']
+            keyAlias = properties['keystore.keyAlias']
+            keyPassword properties['keystore.keyPassword']
         }
         release {
             def properties = getProperties('../local.properties')
             keyAlias properties['keystore.keyAlias']
             keyPassword properties['keystore.keyPassword']
-            storeFile file(properties['keystore.storeFile'])
+            storeFile file('C:\\Users\\tgvit\\tgvita.jks')
             storePassword properties['keystore.storePassword']
 
             v1SigningEnabled true

--- a/app/src/main/java/remix/myplayer/request/ImageUriRequest.java
+++ b/app/src/main/java/remix/myplayer/request/ImageUriRequest.java
@@ -206,9 +206,12 @@ public abstract class ImageUriRequest<T> {
           if (songs.size() > 0) {
 //                        imageUrl = resolveEmbeddedPicture(songs.get(0));
             imageUrl = PREFIX_EMBEDDED + songs.get(0).getUrl();
+
           }
         } else {
           Uri uri;
+
+          /*
           if (request.getSongId() > 0) {
             uri = Uri
                 .parse("content://media/external/audio/media/" + request.getSongId() + "/albumart");
@@ -216,6 +219,9 @@ public abstract class ImageUriRequest<T> {
             uri = ContentUris.withAppendedId(Uri.parse("content://media/external/audio/albumart/"),
                 request.getID());
           }
+          */
+          uri = ContentUris.withAppendedId(Uri.parse("content://media/external/audio/albumart/"),
+                  request.getID());
           if (ImageUriUtil.isAlbumThumbExistInMediaCache(uri)) {
             imageUrl = uri.toString();
           }

--- a/app/src/main/java/remix/myplayer/ui/activity/base/BaseMusicActivity.kt
+++ b/app/src/main/java/remix/myplayer/ui/activity/base/BaseMusicActivity.kt
@@ -300,7 +300,7 @@ open class BaseMusicActivity : BaseActivity(), MusicEventCallback, CoroutineScop
             ToastUtil.show(this, errorTxt)
             return
           }
-          val destination = Uri.fromFile(File(cacheDir, Util.hashKeyForDisk(id.toString() + "")))
+          val destination = Uri.fromFile(File(cacheDir, Util.hashKeyForDisk(id.toString() + "") + ".jpg"))
           Crop.of(data?.data, destination).asSquare().start(this)
         } else {
           //图片裁剪

--- a/app/src/main/java/remix/myplayer/util/ImageUriUtil.java
+++ b/app/src/main/java/remix/myplayer/util/ImageUriUtil.java
@@ -73,13 +73,13 @@ public class ImageUriUtil {
   public static File getCustomThumbIfExist(long id, int type) {
     File img = type == ImageUriRequest.URL_ALBUM ? new File(
         DiskCache.getDiskCacheDir(App.getContext(), "thumbnail/album") + "/" + Util
-            .hashKeyForDisk(id + ""))
+            .hashKeyForDisk(id + "") + ".jpg")
         : type == ImageUriRequest.URL_ARTIST ? new File(
             DiskCache.getDiskCacheDir(App.getContext(), "thumbnail/artist") + "/" + Util
-                .hashKeyForDisk(id + ""))
+                .hashKeyForDisk(id + "") + ".jpg")
             : new File(
                 DiskCache.getDiskCacheDir(App.getContext(), "thumbnail/playlist") + "/" + Util
-                    .hashKeyForDisk(id + ""));
+                    .hashKeyForDisk(id + "") + ".jpg");
     if (img.exists()) {
       return img;
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
+ext {
+    var = 'C:\\Users\\tgvit\\tgvita.jks'
+}// Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
     ext.kotlin_version = '1.3.41'


### PR DESCRIPTION
- Fix IllegalArgumentException while changing album cover on Android Q or later
- Fix: Edited album cover will now apply to all its songs (tricky fix), it seems that the old content:// URI won't do that for us.

TODO:
- Need to kill & restart activity to refresh album cover.
- While "Ignore MediaStore cache" is ON, APlayer will not respect custom album covers but stick to embedded ones. This issue is quite complicated.