### PR TITLE
修复当uri authority为com.android.externalstorage.documents时的错误

### DIFF
--- a/app/src/main/java/remix/myplayer/util/MusicUtil.java
+++ b/app/src/main/java/remix/myplayer/util/MusicUtil.java
@@ -71,7 +71,7 @@ public class MusicUtil {
       }
     }
 
-    if (songs == null) {
+    if (songs == null || songs.size() == 0) {
       File songFile = null;
       if (uri.getAuthority() != null && uri.getAuthority()
           .equals("com.android.externalstorage.documents")) {


### PR DESCRIPTION
monkey patch