### PR TITLE
change<歌曲列表>{调整时间排序方案。}

### DIFF
--- a/app/src/main/java/remix/myplayer/helper/SortOrder.java
+++ b/app/src/main/java/remix/myplayer/helper/SortOrder.java
@@ -24,8 +24,8 @@ public final class SortOrder {
     String SONG_ARTIST_Z_A = SONG_ARTIST_A_Z + " desc ";
     String SONG_ALBUM_A_Z = MediaStore.Audio.Albums.DEFAULT_SORT_ORDER;
     String SONG_ALBUM_Z_A = SONG_ALBUM_A_Z + " desc ";
-    String SONG_DATE = MediaStore.Audio.Media.DATE_ADDED;
-    String SONG_DATE_DESC = MediaStore.Audio.Media.DATE_ADDED + " desc ";
+    String SONG_DATE = MediaStore.Audio.Media.DATE_MODIFIED;
+    String SONG_DATE_DESC = MediaStore.Audio.Media.DATE_MODIFIED + " desc ";
     String SONG_DISPLAY_TITLE_A_Z = Media.DISPLAY_NAME;
     String SONG_DISPLAY_TITLE_Z_A = Media.DISPLAY_NAME + " desc ";
     String SONG_DURATION = MediaStore.Audio.Media.DURATION;


### PR DESCRIPTION
MediaStore.Audio.Media.DATE_ADDED 并不是歌曲真正的添加时间，只是MediaStore的扫描入库时间。所以，建议使用修改时间（对应的是真实的文件修改时间。）可以避免在用户重建MediaStore的索引缓存时导致歌曲顺序紊乱。