### PR TITLE
修复 TextView 选择文本的颜色问题

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,13 @@
 
   <uses-feature android:name="android.hardware.sensor.accelerometer" android:required="false"/>
 
+  <queries>
+    <intent>
+      <action android:name="android.intent.action.PROCESS_TEXT" />
+      <data android:mimeType="text/plain" />
+    </intent>
+  </queries>
+
   <application
     android:allowBackup="true"
     android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/remix/myplayer/ui/misc/AudioTag.kt
+++ b/app/src/main/java/remix/myplayer/ui/misc/AudioTag.kt
@@ -14,13 +14,13 @@ import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.synthetic.main.dialog_song_detail.view.*
 import kotlinx.android.synthetic.main.dialog_song_edit.view.*
 import org.jaudiotagger.audio.AudioFileIO
 import org.jaudiotagger.audio.exceptions.CannotWriteException
 import org.jaudiotagger.tag.FieldKey
 import remix.myplayer.R
 import remix.myplayer.bean.mp3.Song
+import remix.myplayer.databinding.DialogSongDetailBinding
 import remix.myplayer.helper.MusicServiceRemote.getCurrentSong
 import remix.myplayer.misc.cache.DiskCache
 import remix.myplayer.theme.TextInputLayoutUtil
@@ -58,30 +58,35 @@ class AudioTag(val activity: BaseActivity, song: Song?) : ContextWrapper(activit
         .onPositive { _, _ -> disposable?.dispose() }
         .build()
 
-    val view = detailDialog.customView!!
+    val binding = DialogSongDetailBinding.bind(detailDialog.customView!!)
 
-    //歌曲路径
-    view.song_detail_path.text = song.data
-    //歌曲名称
-    view.song_detail_name.text = song.showName
-    //歌曲大小
-    view.song_detail_size.text = getString(R.string.cache_size, 1.0f * song.size / MB)
-    //歌曲时长
-    view.song_detail_duration.text = Util.getTime(song.duration)
+    binding.songDetailPath.text = song.data
+    binding.songDetailName.text = song.showName
+    binding.songDetailSize.text = getString(R.string.cache_size, 1.0f * song.size / MB)
+    binding.songDetailDuration.text = Util.getTime(song.duration)
+
+    arrayOf(
+        binding.songDetailPath,
+        binding.songDetailName,
+        binding.songDetailSize,
+        binding.songDetailMime,
+        binding.songDetailDuration,
+        binding.songDetailBitRate,
+        binding.songDetailSampleRate
+    ).forEach {
+      TintHelper.setTint(it, ThemeStore.accentColor, false)
+    }
 
     disposable = Single.fromCallable { AudioFileIO.read(File(song.data)).audioHeader }
       .observeOn(AndroidSchedulers.mainThread())
       .subscribeOn(Schedulers.io())
       .subscribe(
         { audioHeader ->
-          //歌曲格式
-          view.song_detail_mime.text = audioHeader.format
-          //歌曲码率
+          binding.songDetailMime.text = audioHeader.format
           @SuppressLint("SetTextI18n")
-          view.song_detail_bit_rate.text = "${audioHeader.bitRate} kb/s"
-          //歌曲采样率
+          binding.songDetailBitRate.text = "${audioHeader.bitRate} kb/s"
           @SuppressLint("SetTextI18n")
-          view.song_detail_sample_rate.text = "${audioHeader.sampleRate} Hz"
+          binding.songDetailSampleRate.text = "${audioHeader.sampleRate} Hz"
         }, {
           ToastUtil.show(this, getString(R.string.init_failed, it))
         })

--- a/app/src/main/res/layout/dialog_song_detail.xml
+++ b/app/src/main/res/layout/dialog_song_detail.xml
@@ -1,159 +1,144 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
-  android:orientation="vertical"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:layout_marginTop="@dimen/d18_size">
+    android:layout_marginTop="@dimen/d18_size"
+    android:orientation="horizontal">
     <TextView
+      android:textStyle="bold"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:textSize="@dimen/s16_size"
       android:text="@string/song_path"
-      android:textStyle="bold"
-      android:textColor="@color/detail_text_color"/>
+      android:textSize="@dimen/s16_size" />
     <TextView
       android:id="@+id/song_detail_path"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:textSize="@dimen/s16_size"
-      android:textColor="@color/detail_text_color"
-      android:textIsSelectable="true"/>
+      android:textIsSelectable="true"
+      android:textSize="@dimen/s16_size" />
   </LinearLayout>
 
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:layout_marginTop="@dimen/d18_size">
+    android:layout_marginTop="@dimen/d18_size"
+    android:orientation="horizontal">
     <TextView
+      android:textStyle="bold"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:textSize="@dimen/s16_size"
       android:text="@string/song_name"
-      android:textStyle="bold"
-      android:textColor="@color/detail_text_color"/>
+      android:textSize="@dimen/s16_size" />
     <TextView
       android:id="@+id/song_detail_name"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:textSize="@dimen/s16_size"
-      android:textColor="@color/detail_text_color"
-      android:textIsSelectable="true"/>
+      android:textIsSelectable="true"
+      android:textSize="@dimen/s16_size" />
   </LinearLayout>
 
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:layout_marginTop="@dimen/d18_size">
+    android:layout_marginTop="@dimen/d18_size"
+    android:orientation="horizontal">
     <TextView
+      android:textStyle="bold"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:textSize="@dimen/s16_size"
       android:text="@string/file_size"
-      android:textStyle="bold"
-      android:textColor="@color/detail_text_color"/>
+      android:textSize="@dimen/s16_size" />
     <TextView
       android:id="@+id/song_detail_size"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:textSize="@dimen/s16_size"
-      android:textColor="@color/detail_text_color"
-      android:textIsSelectable="true"/>
+      android:textIsSelectable="true"
+      android:textSize="@dimen/s16_size" />
   </LinearLayout>
 
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:layout_marginTop="@dimen/d18_size">
+    android:layout_marginTop="@dimen/d18_size"
+    android:orientation="horizontal">
     <TextView
+      android:textStyle="bold"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:textSize="@dimen/s16_size"
       android:text="@string/format"
-      android:textStyle="bold"
-      android:textColor="@color/detail_text_color"/>
+      android:textSize="@dimen/s16_size" />
     <TextView
       android:id="@+id/song_detail_mime"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:text="@string/loading"
-      android:textSize="@dimen/s16_size"
-      android:textColor="@color/detail_text_color"
-      android:textIsSelectable="true"/>
+      android:textIsSelectable="true"
+      android:textSize="@dimen/s16_size" />
   </LinearLayout>
 
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:layout_marginTop="@dimen/d18_size">
+    android:layout_marginTop="@dimen/d18_size"
+    android:orientation="horizontal">
     <TextView
+      android:textStyle="bold"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:textSize="@dimen/s16_size"
       android:text="@string/length"
-      android:textStyle="bold"
-      android:textColor="@color/detail_text_color"/>
+      android:textSize="@dimen/s16_size" />
     <TextView
       android:id="@+id/song_detail_duration"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:textSize="@dimen/s16_size"
-      android:textColor="@color/detail_text_color"
-      android:textIsSelectable="true"/>
+      android:textIsSelectable="true"
+      android:textSize="@dimen/s16_size" />
   </LinearLayout>
 
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:layout_marginTop="@dimen/d18_size">
+    android:layout_marginTop="@dimen/d18_size"
+    android:orientation="horizontal">
     <TextView
+      android:textStyle="bold"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:textSize="@dimen/s16_size"
       android:text="@string/bitrate"
-      android:textStyle="bold"
-      android:textColor="@color/detail_text_color"/>
+      android:textSize="@dimen/s16_size" />
     <TextView
       android:id="@+id/song_detail_bit_rate"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:text="@string/loading"
-      android:textSize="@dimen/s16_size"
-      android:textColor="@color/detail_text_color"
-      android:textIsSelectable="true"/>
+      android:textIsSelectable="true"
+      android:textSize="@dimen/s16_size" />
   </LinearLayout>
 
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
     android:layout_marginTop="@dimen/d18_size"
-    android:visibility="gone">
+    android:orientation="horizontal">
     <TextView
+      android:textStyle="bold"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:textSize="@dimen/s16_size"
       android:text="@string/sample_rate"
-      android:textStyle="bold"
-      android:textColor="@color/detail_text_color"/>
+      android:textSize="@dimen/s16_size" />
     <TextView
       android:id="@+id/song_detail_sample_rate"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:text="@string/loading"
-      android:textSize="@dimen/s16_size"
-      android:textColor="@color/detail_text_color"
-      android:textIsSelectable="true"/>
+      android:textIsSelectable="true"
+      android:textSize="@dimen/s16_size" />
   </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -65,8 +65,6 @@
   <color name="light_normal_tab_text_color">#99ffffff</color>
   <color name="dark_normal_tab_text_color">@color/dark_text_color_secondary</color>
 
-  <color name="detail_text_color">#737373</color>
-
   <color name="default_accent_color">#555393</color>
   <color name="player_top_detail_text_color">#7e7e7e</color>
   <color name="player_time_text_color">#6b6b6b</color>


### PR DESCRIPTION
之前选择的时候光标和被选中文字的背景都是默认颜色，不是应用的强调色

|now|before|
|:-:|:-:|
|![](https://user-images.githubusercontent.com/51886614/124356969-b60e9900-dc4b-11eb-9e14-5330e425d496.png)|![](https://user-images.githubusercontent.com/51886614/124356971-b9098980-dc4b-11eb-823f-76f9a0c41201.png)|

---

那个 `<queries>` 是那个三点菜单用的