### PR TITLE
fix: NetEase search API

### DIFF
--- a/app/src/main/java/remix/myplayer/request/network/ApiService.kt
+++ b/app/src/main/java/remix/myplayer/request/network/ApiService.kt
@@ -32,17 +32,17 @@ interface ApiService {
   fun searchLastFMArtist(@Query("artist") artistName: String?,
                          @Query("lang") language: String?): Single<LastFmArtist>
 
-  @POST("search/pc")
+  @GET("search/get")
   @Headers("User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36")
   fun searchNeteaseSong(@Query("s") key: String?, @Query("offset") offset: Int,
                         @Query("limit") limit: Int, @Query("type") type: Int): Single<NSongSearchResponse>
 
-  @POST("search/pc")
+  @GET("search/get")
   @Headers("User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36")
   fun searchNeteaseAlbum(@Query("s") key: String?, @Query("offset") offset: Int,
                          @Query("limit") limit: Int, @Query("type") type: Int): Single<NAlbumSearchResponse>
 
-  @POST("search/pc")
+  @GET("search/get")
   @Headers("User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36")
   fun searchNeteaseArtist(@Query("s") key: String?, @Query("offset") offset: Int,
                           @Query("limit") limit: Int, @Query("type") type: Int): Single<NArtistSearchResponse>


### PR DESCRIPTION
#155 中提到的网易云原搜索接口要求登录，对搜索接口进行更换以取得歌曲id
之前提过的排序问题我也没什么好的想法，总之先修到恢复原先的功能好了