### PR TITLE
Fixed # 由于Mediaplayer发生错误导致播放停止的问题。

### DIFF
--- a/app/src/main/java/remix/myplayer/service/MusicService.kt
+++ b/app/src/main/java/remix/myplayer/service/MusicService.kt
@@ -672,11 +672,16 @@ class MusicService : BaseService(), Playback, MusicEventCallback,
 
     mediaPlayer.setOnErrorListener { mp, what, extra ->
       try {
-        prepared = false
-        mediaPlayer.release()
-        setUpPlayer()
-        ToastUtil.show(service, R.string.mediaplayer_error, what, extra)
-        return@setOnErrorListener true
+        if(what == 100){
+          service.updatePlaybackState();
+          ToastUtil.show(service, R.string.mediaplayer_error_ignore, what, extra)
+        }else {
+          prepared = false
+          mediaPlayer.release()
+          setUpPlayer()
+          ToastUtil.show(service, R.string.mediaplayer_error, what, extra)
+          return@setOnErrorListener true
+        }
       } catch (ignored: Exception) {
 
       }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -227,6 +227,7 @@
   <string name="desktop_lyric__lock_ticker">桌面歌词已锁定，可在通知栏解锁</string>
   <string name="desktop_lyric__unlock">桌面歌词已解除锁定</string>
   <string name="mediaplayer_error">MediaPlayer{what:%1$d,extra:%2$d}\n正在重新初始化</string>
+  <string name="mediaplayer_error_ignore">播放下一首!\n 因为: MediaPlayer{what:%1$d,extra:%2$d}!</string>
   <string name="screen_always_on_title">歌词界面屏幕常亮</string>
   <string name="screen_always_on_tip">开启后切换到歌词界面屏幕将常亮</string>
   <string name="plz_give_float_permission">请在设置中授予悬浮窗权限</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -226,6 +226,7 @@
   <string name="desktop_lyric__lock_ticker">浮動歌詞已鎖定，可在通知列解鎖</string>
   <string name="desktop_lyric__unlock">浮動歌詞已解除鎖定</string>
   <string name="mediaplayer_error">MediaPlayer{what:%1$d,extra:%2$d}\n正在重新初始化</string>
+  <string name="mediaplayer_error_ignore">播放下一曲目!\n 因為: MediaPlayer{what:%1$d,extra:%2$d}!</string>
   <string name="screen_always_on_title">歌詞頁面螢幕保持開啟</string>
   <string name="screen_always_on_tip">開啟後切換到歌詞頁面螢幕將暫停休眠</string>
   <string name="plz_give_float_permission">請在設定中授予顯示在其他應用程式上層權限</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -227,6 +227,7 @@
   <string name="desktop_lyric__lock_ticker">浮動歌詞已鎖定，可在通知列解鎖</string>
   <string name="desktop_lyric__unlock">浮動歌詞已解除鎖定</string>
   <string name="mediaplayer_error">MediaPlayer{what:%1$d,extra:%2$d}\n正在重新初始化</string>
+  <string name="mediaplayer_error_ignore">播放下一曲目!\n 因為: MediaPlayer{what:%1$d,extra:%2$d}!</string>
   <string name="screen_always_on_title">在歌詞頁面螢幕保持開啟</string>
   <string name="screen_always_on_tip">開啟後切換到歌詞頁面螢幕將暫停休眠</string>
   <string name="plz_give_float_permission">請在設定中授予顯示在其他應用程式上層權限</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -227,6 +227,7 @@
   <string name="desktop_lyric__lock_ticker">The desktop lyric is locked and can be unlocked in the notification bar</string>
   <string name="desktop_lyric__unlock">The desktop lyric has been unlocked</string>
   <string name="mediaplayer_error">MediaPlayer{what:%1$d,extra:%2$d}\n  is being reinitialized</string>
+  <string name="mediaplayer_error_ignore">playing the next one!\n Cause: MediaPlayer{what:%1$d,extra:%2$d}!</string>
   <string name="screen_always_on_title">Lyric page screen always on</string>
   <string name="screen_always_on_tip">The screen is always on when you are in lyric page</string>
   <string name="plz_give_float_permission">Grant floating window permissionin settings</string>


### PR DESCRIPTION
Fixed # 由于Mediaplayer发生`android.media.MediaPlayer.MEDIA_ERROR_SERVER_DIED`错误导致播放停止的问题。
实测，`what`为`100`的错误`MEDIA_ERROR_SERVER_DIED`只发生在当前歌曲，可以继续播放下一首，而不是播放就停了，比如在后台播放，发生错误的时候，如果停止了，需要手动播放下一首，比较麻烦。
而且，如果发生`100`的错误后`relase`播放器并重新`setup`播放器，在我这边貌似会增加后续继续发生这个错误的概率。