### PR TITLE
修复历史播放列表按时间排序时，子菜单选项会显示未选中的问题

### DIFF
--- a/app/src/main/java/remix/myplayer/ui/activity/MenuActivity.kt
+++ b/app/src/main/java/remix/myplayer/ui/activity/MenuActivity.kt
@@ -170,6 +170,8 @@ abstract class MenuActivity : ToolbarActivity() {
       SortOrder.PLAYLIST_SONG_CUSTOM -> subMenu.findItem(R.id.action_sort_order_custom).isChecked = true
       SortOrder.PLAY_COUNT -> subMenu.findItem(R.id.action_sort_order_play_count).isChecked = true
       SortOrder.PLAY_COUNT_DESC -> subMenu.findItem(R.id.action_sort_order_play_count_desc).isChecked = true
+      SortOrder.LASTPLAY -> subMenu.findItem(R.id.action_sort_order_last_play).isChecked = true
+      SortOrder.LASTPLAY_DESC -> subMenu.findItem(R.id.action_sort_order_last_play_desc).isChecked = true
     }
   }
 


### PR DESCRIPTION
修复历史播放列表中选择按照播放时间和播放时间降序排序时，退出后重新进入，子菜单选项会显示未选中的问题