### PR TITLE
统一歌词顺序选单文字绘制方式以适配夜间模式

### DIFF
--- a/app/src/main/java/remix/myplayer/ui/screen/setting/logic/lyric/LyricPriorityLogic.kt
+++ b/app/src/main/java/remix/myplayer/ui/screen/setting/logic/lyric/LyricPriorityLogic.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -31,6 +30,7 @@ import remix.myplayer.ui.dialog.rememberDialogState
 import remix.myplayer.ui.nav.MessageNotifier
 import remix.myplayer.ui.screen.setting.NormalPreference
 import remix.myplayer.ui.theme.LocalTheme
+import remix.myplayer.ui.widget.common.TextPrimary
 import remix.myplayer.util.Util
 import remix.myplayer.util.ext.ShowLyricTipDialog
 import remix.myplayer.viewmodel.settingViewModel
@@ -87,7 +87,7 @@ fun LyricPriorityLogic() {
                 .height(48.dp),
               contentAlignment = Alignment.CenterStart
             ) {
-              Text(
+              TextPrimary(
                 text = stringResource(lyricOrder.stringRes),
                 fontSize = 16.sp,
                 textAlign = TextAlign.Center


### PR DESCRIPTION
Change Text to TextPrimary in LyricPriorityLogic，使其在黑暗模式下的绘制方式符合黑暗模式配色
#369 
<img width="720" height="1280" alt="MuMu12-20260329-032256" src="https://github.com/user-attachments/assets/e567092e-f5c6-40e0-86ee-f3272ac78d9a" />
