### PR TITLE
集成 SuperLyricApi 以支持发布歌词

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -262,6 +262,7 @@ dependencies {
     implementation(libs.slf4j)
     implementation(libs.timber)
     implementation(libs.tinypinyin)
+    implementation(libs.superlyricapi)
 
     debugImplementation(libs.leakcanary)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-  xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
     android:maxSdkVersion="32" />
@@ -30,6 +30,8 @@
       <data android:mimeType="text/plain" />
     </intent>
   </queries>
+
+  <uses-sdk tools:overrideLibrary="com.hchen.superlyricapi" />
 
   <application
     android:allowBackup="true"

--- a/app/src/main/java/remix/myplayer/data/prefs/LyricPrefs.kt
+++ b/app/src/main/java/remix/myplayer/data/prefs/LyricPrefs.kt
@@ -35,6 +35,7 @@ class LyricPrefs @Inject constructor(
 
   var desktopLyricEnabled by PrefsDelegate(sp, KEY_DESKTOP_LYRIC_ENABLED, false)
   var statusBarLyricEnabled by PrefsDelegate(sp, KEY_STATUS_BAR_LYRIC_ENABLED, false)
+  var superLyricApiEnabled by PrefsDelegate(sp, KEY_SUPER_LYRIC_API_ENABLED, false)
 
   var fontScale by PrefsDelegate(sp, KEY_LYRIC_FONT_SCALE, 1.0f)
 
@@ -65,6 +66,9 @@ class LyricPrefs @Inject constructor(
 
     // StatusBar
     const val KEY_STATUS_BAR_LYRIC_ENABLED: String = "status_bar_lyric_enabled"
+
+    // SuperLyricApi
+    const val KEY_SUPER_LYRIC_API_ENABLED: String = "super_lyric_api_enabled"
 
     // Desktop
     const val KEY_DESKTOP_LYRIC_ENABLED: String = "desktop_lyric_enabled"

--- a/app/src/main/java/remix/myplayer/lyric/LyricManager.kt
+++ b/app/src/main/java/remix/myplayer/lyric/LyricManager.kt
@@ -21,6 +21,10 @@ import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryController
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import com.hchen.superlyricapi.SuperLyricData
+import com.hchen.superlyricapi.SuperLyricHelper
+import com.hchen.superlyricapi.SuperLyricLine
+import com.hchen.superlyricapi.SuperLyricWord
 import com.hjq.permissions.Permission
 import com.hjq.permissions.XXPermissions
 import dagger.hilt.EntryPoint
@@ -195,11 +199,30 @@ class LyricManager @Inject constructor(
       updateStatusBarLyric()
     }
 
+  var isSuperLyricApiEnabled: Boolean
+    get() = lyricPrefs.superLyricApiEnabled
+    set(value) {
+      lyricPrefs.superLyricApiEnabled = value
+
+      if (SuperLyricHelper.isAvailable()) {
+        if (value) {
+          if (!SuperLyricHelper.isPublisherRegistered()) {
+            SuperLyricHelper.registerPublisher()
+          }
+        } else {
+          if (SuperLyricHelper.isPublisherRegistered()) {
+            SuperLyricHelper.unregisterPublisher()
+          }
+        }
+      }
+      updateSuperLyric()
+    }
+
   @UiThread
   private fun ensureDesktopLyric() {
     val shouldShow =
       isServiceAvailable && isNotifyShowing && isScreenOn && !isAppInForeground && isDesktopLyricEnabled &&
-          (!isDesktopLyricLocked || isPlaying)
+              (!isDesktopLyricLocked || isPlaying)
     if (shouldShow != (desktopLyricView != null)) {
       if (shouldShow) {
         createDesktopLyric()
@@ -399,6 +422,7 @@ class LyricManager @Inject constructor(
         }
       }
       updateStatusBarLyric()
+      updateSuperLyric()
       ensureDesktopLyric()
     }
   private var progress: Long = 0
@@ -424,19 +448,90 @@ class LyricManager @Inject constructor(
       }
       field = value
       updateStatusBarLyric()
+      updateSuperLyric()
     }
 
   private fun updateStatusBarLyric() {
     val service = MusicServiceRemote.service ?: return
     val lyricLine = currentLyricsLine
     val shouldShow = isStatusBarLyricEnabled && isPlaying &&
-        lyricLine.isNotBlank() &&
-        lyricLine != LyricLine.LYRICS_LINE_NO_LRC.content
+            lyricLine.isNotBlank() &&
+            lyricLine != LyricLine.LYRICS_LINE_NO_LRC.content
 
     if (shouldShow) {
       service.updateNotificationWithLrc(lyricLine)
     } else {
       service.clearStatusBarLyricNotification()
+    }
+  }
+
+  private fun updateSuperLyric() {
+    if (!isSuperLyricApiEnabled) {
+      return
+    }
+
+    if (isPlaying) {
+      val lyricLine = currentLyricsLine
+      val shouldShow = lyricLine.isNotBlank() &&
+              lyricLine != LyricLine.LYRICS_LINE_NO_LRC.content &&
+              lyricLine != LyricLine.LYRICS_LINE_SEARCHING.content
+
+      if (shouldShow) {
+        val song = MusicStateSource.playbackUiState.value.song
+        val progress = MusicStateSource.progressState.value
+        val lyrics = currentNextLyricsLine.value
+        if (SuperLyricHelper.isAvailable()) {
+          if (lyrics.currentLine != null) {
+            val superLine = when (lyrics.currentLine) {
+              is PerWordLyricLine -> {
+                SuperLyricLine(
+                  lyrics.currentLine.content,
+                  Array(lyrics.currentLine.words.size) { index ->
+                    val word = lyrics.currentLine.words[index]
+                    if (index != lyrics.currentLine.words.size - 1) {
+                      val nextWord = lyrics.currentLine.words[index + 1]
+                      SuperLyricWord(
+                        word.content,
+                        word.time,
+                        nextWord.time
+                      )
+                    } else {
+                      SuperLyricWord(
+                        word.content,
+                        word.time,
+                        lyrics.nextLine?.time ?: (progress.duration + offset)
+                      )
+                    }
+                  },
+                  lyrics.currentLine.time,
+                  lyrics.nextLine?.time ?: (progress.duration + offset)
+                )
+              }
+
+              else -> {
+                SuperLyricLine(
+                  lyrics.currentLine.content,
+                  lyrics.currentLine.time,
+                  lyrics.nextLine?.time ?: (progress.duration + offset)
+                )
+              }
+            }
+
+            SuperLyricHelper.sendLyric(
+              SuperLyricData()
+                .setTitle(song.title)
+                .setArtist(song.artist)
+                .setAlbum(song.album)
+                .setLyric(superLine)
+                .setTranslation(SuperLyricLine(lyrics.currentLine.translation ?: ""))
+            )
+          }
+        }
+      }
+    } else {
+      SuperLyricHelper.sendStop(
+        SuperLyricData()
+      )
     }
   }
 

--- a/app/src/main/java/remix/myplayer/ui/screen/setting/SettingScreen.kt
+++ b/app/src/main/java/remix/myplayer/ui/screen/setting/SettingScreen.kt
@@ -41,6 +41,7 @@ import remix.myplayer.ui.screen.setting.logic.library.LibraryLogic
 import remix.myplayer.ui.screen.setting.logic.lyric.DesktopLyricLogic
 import remix.myplayer.ui.screen.setting.logic.lyric.LyricPriorityLogic
 import remix.myplayer.ui.screen.setting.logic.lyric.StatusBarLyricLogic
+import remix.myplayer.ui.screen.setting.logic.lyric.SuperLyricApiLogic
 import remix.myplayer.ui.screen.setting.logic.notification.ClassicNotifyLogic
 import remix.myplayer.ui.screen.setting.logic.notification.NotifyBackgroundLogic
 import remix.myplayer.ui.screen.setting.logic.other.ClearCacheLogic
@@ -261,6 +262,8 @@ private fun LyricPreferenceItems() {
   DesktopLyricLogic()
 
   StatusBarLyricLogic()
+
+  SuperLyricApiLogic()
 
   LyricPriorityLogic()
 }

--- a/app/src/main/java/remix/myplayer/ui/screen/setting/logic/lyric/SuperLyricApiLogic.kt
+++ b/app/src/main/java/remix/myplayer/ui/screen/setting/logic/lyric/SuperLyricApiLogic.kt
@@ -1,0 +1,26 @@
+package remix.myplayer.ui.screen.setting.logic.lyric
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hchen.superlyricapi.SuperLyricHelper
+import remix.myplayer.ui.screen.setting.SwitchPreference
+import remix.myplayer.viewmodel.settingViewModel
+
+@Composable
+fun SuperLyricApiLogic() {
+  if (!SuperLyricHelper.isAvailable()) {
+    return
+  }
+
+  val settingVM = settingViewModel
+  val settingState by settingVM.settingsState.collectAsStateWithLifecycle()
+
+  SwitchPreference(
+    title = "SuperLyricApi",
+    content = "API version: ${SuperLyricHelper.getApiVersion()}",
+    checked = settingState.lyric.superLyricApiEnabled
+  ) {
+    settingVM.setSuperLyricApiEnabled(it)
+  }
+}

--- a/app/src/main/java/remix/myplayer/viewmodel/settings/SettingState.kt
+++ b/app/src/main/java/remix/myplayer/viewmodel/settings/SettingState.kt
@@ -75,6 +75,7 @@ data class CoverSettings(
 data class LyricSettings(
   val desktopLyricEnabled: Boolean,
   val statusBarLyricEnabled: Boolean,
+  val superLyricApiEnabled: Boolean,
   val fontScale: Float,
   val generalLyricOrder: List<LyricOrder>,
 )

--- a/app/src/main/java/remix/myplayer/viewmodel/settings/SettingViewModel.kt
+++ b/app/src/main/java/remix/myplayer/viewmodel/settings/SettingViewModel.kt
@@ -125,6 +125,7 @@ class SettingViewModel @Inject constructor(
     lyric = LyricSettings(
       desktopLyricEnabled = lyricPrefs.desktopLyricEnabled,
       statusBarLyricEnabled = lyricPrefs.statusBarLyricEnabled,
+      superLyricApiEnabled = lyricPrefs.superLyricApiEnabled,
       fontScale = lyricPrefs.fontScale,
       generalLyricOrder = lyricPrefs.generalLyricOrderList
     ),
@@ -356,6 +357,11 @@ class SettingViewModel @Inject constructor(
   fun setStatusBarLyricEnabled(enabled: Boolean) {
     lyricManager.isStatusBarLyricEnabled = enabled
     _settingsState.update { it.copy(lyric = it.lyric.copy(statusBarLyricEnabled = enabled)) }
+  }
+
+  fun setSuperLyricApiEnabled(enabled: Boolean) {
+    lyricManager.isSuperLyricApiEnabled = enabled
+    _settingsState.update { it.copy(lyric = it.lyric.copy(superLyricApiEnabled = enabled)) }
   }
 
   fun setLyricFontScale(scale: Float) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ glideCompose = "1.0.0-beta01"
 retrofit = "3.0.0"
 retrofitKotlinxSerialization = "1.0.0"
 room = "2.7.2"
+superlyricapi = "3.3"
 xxpermissions = "21.2"
 workRuntimeKtx = "2.10.4"
 activityCompose = "1.10.1"
@@ -102,6 +103,7 @@ image-cropper = { module = "com.vanniktech:android-image-cropper", version.ref =
 bugly = { group = "com.tencent.bugly", name = "crashreport", version.ref = "bugly" }
 leakcanary = { group = "com.squareup.leakcanary", name = "leakcanary-android", version.ref = "leakcanary" }
 logback-android = { group = "com.github.tony19", name = "logback-android", version.ref = "logbackAndroid" }
+superlyricapi = { module = "com.github.HChenX:SuperLyricApi", version.ref = "superlyricapi" }
 xxpermissions = { module = "com.github.getActivity:XXPermissions", version.ref = "xxpermissions" }
 sardine-android = { group = "com.github.thegrizzlylabs", name = "sardine-android", version.ref = "sardineAndroid" }
 smbj = { group = "com.hierynomus", name = "smbj", version.ref = "smbj" }


### PR DESCRIPTION
- 在 `build.gradle.kts` 和 `libs.versions.toml` 中添加 `com.github.HChenX:SuperLyricApi` 依赖。
- 在 `AndroidManifest.xml` 中添加 `tools:overrideLibrary` 声明以适配库引入。
- 在 `LyricPrefs` 和 `LyricSettings` 中增加 `superLyricApiEnabled` 配置项。
- 在 `LyricManager` 中实现 `SuperLyricApi` 的注册、反注册以及歌词数据的实时发送逻辑，支持逐字歌词 (Per-word lyric) 传输。
- 在设置页面增加 `SuperLyricApi` 的开关控制及 API 版本显示。

SuperLyricApi 是本人的一个获取音乐软件歌词并进行广播的 API，希望能适配本应用，为接收端提供歌词数据，万分感谢！